### PR TITLE
Add genetic code 15

### DIFF
--- a/bin/proovframe-fix
+++ b/bin/proovframe-fix
@@ -239,6 +239,7 @@ sub stop_codons{
         12=> "TAA|TAG|TGA",
         13=> "TAA|TAG",
         14=> "TAG",
+        15=> "TAA|TGA",
         16=> "TAA|TGA",
         21=> "TAA|TAG",
         22=> "TCA|TAA|TGA",


### PR DESCRIPTION
used by Crassvirales.
See
* [Experimental validation that human microbiome phages use alternative genetic coding](https://www.nature.com/articles/s41467-022-32979-6). Peters et al., Nature Communications 2022
* https://www.nature.com/articles/s41564-018-0338-9